### PR TITLE
Changed where hackney compiles its metrics module

### DIFF
--- a/src/hackney_app.erl
+++ b/src/hackney_app.erl
@@ -20,6 +20,8 @@
 %% ===================================================================
 
 start(_StartType, _StartArgs) ->
+  Metrics = metrics:init(hackney_util:mod_metrics()),
+  application:set_env(hackney, metrics, Metrics),
   hackney_sup:start_link().
 
 stop(_State) ->

--- a/src/hackney_connect.erl
+++ b/src/hackney_connect.erl
@@ -66,7 +66,7 @@ create_connection(Transport, Host, Port, Options, Dynamic)
   MaxBody = proplists:get_value(max_body, Options),
 
   %% get mod metrics
-  Engine = metrics:init(hackney_util:mod_metrics()),
+  {ok, Engine} = application:get_env(hackney, metrics),
 
   %% initial state
   InitialState = #client{mod_metrics=Engine,


### PR DESCRIPTION
Under erlang 20, compilation is slower, and compiling the metrics
module when a connection is created doesn't make sense, as this can
cause the whole code server to become buried under recompilation
requests. This moves compilation to the application's start.